### PR TITLE
add roulette sketch

### DIFF
--- a/p5-sketches/sketch.js
+++ b/p5-sketches/sketch.js
@@ -25,6 +25,7 @@ function setup() {
 
   angleMode(DEGREES);
 
+  // Set text color, size, and alignment
   fill(255);
   textSize(20);
   textAlign(CENTER, CENTER);
@@ -78,12 +79,12 @@ function draw() {
   background(0);
   static_lines();
   translate(width / 2, height / 2);
-  rotate(frameCount / 20 * rotation_speed);
+  rotate(duration * rotation_speed);
   draw_roulette();
-  if (rotation_speed >= 0) {
-    rotation_speed -= 1
+  if (duration >= 0) {
+    duration -= 1
   } else {
-    return get_map_name();
+    get_map_name();
   }
 }
 
@@ -97,7 +98,8 @@ function static_lines() {
 }
 
 function mousePressed() { // Spin the wheel. Random rotation does not work so far.
-  rotation_speed = floor(random(0, 360));
+  rotation_speed = floor(random(0, 500));
+  duration = floor(random(1, 25))
 }
 function get_map_name() { // Find hue from the RGB value returned by get
   translate(0, 0);

--- a/p5-sketches/sketch.js
+++ b/p5-sketches/sketch.js
@@ -1,3 +1,4 @@
+// Hold and release a mouse button to spin the wheel
 const Maps = new Map([
   [1, "No Mercy"],
   [2, "Crash Course"],
@@ -14,12 +15,13 @@ const Maps = new Map([
   [13, "The Parish"],
   [14, "Cold Stream"]
 ]);
-const CringeMaps = ["Crash Course", "The Sacrifice", "The Last Stand", "The Passing", "Cringe Map"];
+const CringeMaps = ["Crash Course", "The Sacrifice", "The Last Stand", "The Passing"];
 let maps_by_colour = new Map();
 let rotation_speed = 0;
 let colour_slice = 0;
 let duration = 10;
 let final_colour = 0;
+let wheel_spun = false;
 function setup() {
   createCanvas(800, 800);
 
@@ -50,14 +52,14 @@ function draw_roulette() {
     // Set color based on angle and draw arc representing each circle slice
     colour_slice = angle;
     stroke(angle, 100, 100);
-    fill(angle, 100, 50);
+    fill(angle, 100, 30);
     strokeWeight(5);
     //line(0, 0, 250, 0);
     arc(0, 0, 600, 600, 0, PI * 7.6);
     if (i <= 14) {
       current_map = Maps.get(i);
       stroke(0);
-      fill(angle, 100, 100);
+      fill(angle, 40, 100);
       strokeWeight(2);
       text(current_map, 220, 15);
       maps_by_colour.set(colour_slice, current_map)
@@ -66,9 +68,9 @@ function draw_roulette() {
       pop()
     } else {
       stroke(0);
-      fill(angle, 100, 100);
+      fill(angle, 40, 100);
       strokeWeight(2);
-      text("Cringe Map", 220, 15);
+      text("Reroll", 220, 15);
       // Restore coordinate system
       pop()
     }
@@ -76,73 +78,98 @@ function draw_roulette() {
 }
 
 function draw() {
-  background(0);
+  background(10);
   static_lines();
-  translate(width / 2, height / 2);
-  rotate(duration * rotation_speed);
-  draw_roulette();
-  if (duration >= 0) {
-    duration -= 1
-  } else {
+  if (mouseIsPressed === true) {
+    translate(width / 2, height / 2);
+    rotate(frameCount);
+    draw_roulette();
+  } else if (wheel_spun === false) {
+    translate(width / 2, height / 2);
+    rotate(frameCount / 20);
+    draw_roulette();
     get_map_name();
+  } else {
+    translate(width / 2, height / 2);
+    rotate(duration + rotation_speed);
+    draw_roulette();
+    if (duration >= 0 && duration <= 100) {
+      duration -= 1
+    } else if (duration >= 100) {
+      duration /= 1.1
+    } else {
+      get_map_name();
+    }
   }
 }
 
 function static_lines() {
   translate(0, 0)
-  stroke(0, 255, 255);
+  stroke(0, 50, 100);
   strokeWeight(5);
   line(width, height, width - 180, height - 180);
   line(width - 180, height - 180, width - 75, height - 150);
   line(width - 180, height - 180, width - 150, height - 75);
 }
 
-function mousePressed() { // Spin the wheel. Random rotation does not work so far.
+function mouseReleased() { // Spin the wheel.
   rotation_speed = floor(random(0, 500));
-  duration = floor(random(1, 25))
+  duration = floor(random(200, 4500));
+  wheel_spun = true;
 }
 function get_map_name() { // Find hue from the RGB value returned by get
-  translate(0, 0);
-  final_colour = get(width - 200, height - 200)
-  let max_rg_b = Math.max(final_colour[0], final_colour[1], final_colour[2]);
-  let min_rg_b = Math.min(final_colour[0], final_colour[1], final_colour[2]);
-  let hue_final = 0;
-
-  // all greyscale colors have hue of 0deg
-  if (max_rg_b - min_rg_b == 0) {
-    hue_final = 0;
-  }
-
-  else if (max_rg_b == final_colour[0]) {
-    // if red is the predominant color
-    hue_final = (final_colour[1] - final_colour[2]) / (max_rg_b - min_rg_b);
-  }
-  else if (max_rg_b == final_colour[1]) {
-    // if green is the predominant color
-    hue_final = 2 + (final_colour[2] - final_colour[0]) / (max_rg_b - min_rg_b);
-  }
-  else if (max_rg_b == final_colour[2]) {
-    // if blue is the predominant color
-    hue_final = 4 + (final_colour[0] - final_colour[1]) / (max_rg_b - min_rg_b);
-  }
-
-  hue_final = hue_final * 60;
-
-  // make sure h is a positive angle on the color wheel between 0 and 360
-  hue_final %= 360;
-  if (hue_final < 0) {
-    hue_final += 360;
-  }
-  stroke(0);
-  fill(hue_final, 100, 100);
-  strokeWeight(15);
-  hue_final = Math.round(hue_final);
-  final_map = maps_by_colour.get(hue_final)
-  resetMatrix()
-  if (CringeMaps.includes(final_map) || final_map === undefined) {
-    text("CRINGE MAP: Time to reroll", width - 250, height - 30);
+  if (wheel_spun === false) {
+    stroke(30);
+    fill(0, 50, 100);
+    strokeWeight(15);
+    resetMatrix();
+    text("Hold and release to spin the wheel", width - 250, height - 30);
   } else {
-    final_map = "The chosen map is: " + final_map
-    text(final_map, width - 250, height - 30);
+    translate(0, 0);
+    final_colour = get(width - 190, height - 190)
+    let max_rg_b = Math.max(final_colour[0], final_colour[1], final_colour[2]);
+    let min_rg_b = Math.min(final_colour[0], final_colour[1], final_colour[2]);
+    let hue_final = 0;
+
+    // all greyscale colors have hue of 0deg
+    if (max_rg_b - min_rg_b == 0) {
+      hue_final = 0;
+    }
+
+    else if (max_rg_b == final_colour[0]) {
+      // if red is the predominant color
+      hue_final = (final_colour[1] - final_colour[2]) / (max_rg_b - min_rg_b);
+    }
+    else if (max_rg_b == final_colour[1]) {
+      // if green is the predominant color
+      hue_final = 2 + (final_colour[2] - final_colour[0]) / (max_rg_b - min_rg_b);
+    }
+    else if (max_rg_b == final_colour[2]) {
+      // if blue is the predominant color
+      hue_final = 4 + (final_colour[0] - final_colour[1]) / (max_rg_b - min_rg_b);
+    }
+
+    hue_final = hue_final * 60;
+
+    // make sure h is a positive angle on the color wheel between 0 and 360
+    hue_final %= 360;
+    if (hue_final < 0) {
+      hue_final += 360;
+    }
+    stroke(30);
+    fill(hue_final, 50, 100);
+    strokeWeight(15);
+    hue_final = Math.round(hue_final);
+    final_map = maps_by_colour.get(hue_final)
+    resetMatrix()
+    if (final_map === undefined) {
+      text("Lucky you: Time to reroll", width - 250, height - 30);
+    } else if (CringeMaps.includes(final_map)) {
+      final_map = "CRINGE MAP: " + final_map
+      text(final_map, width - 250, height - 30);
+    } else {
+      final_map = "The chosen map is: " + final_map
+      text(final_map, width - 250, height - 30);
+    }
   }
 }

--- a/p5-sketches/sketch.js
+++ b/p5-sketches/sketch.js
@@ -1,0 +1,146 @@
+const Maps = new Map([
+  [1, "No Mercy"],
+  [2, "Crash Course"],
+  [3, "Death Toll"],
+  [4, "Dead Air"],
+  [5, "Blood Harvest"],
+  [6, "The Sacrifice"],
+  [7, "The Last Stand"],
+  [8, "Dead Center"],
+  [9, "The Passing"],
+  [10, "Dark Carnival"],
+  [11, "Swamp Fever"],
+  [12, "Hard Rain"],
+  [13, "The Parish"],
+  [14, "Cold Stream"]
+]);
+const CringeMaps = ["Crash Course", "The Sacrifice", "The Last Stand", "The Passing", "Cringe Map"];
+let maps_by_colour = new Map();
+let rotation_speed = 0;
+let colour_slice = 0;
+let duration = 10;
+let final_colour = 0;
+function setup() {
+  createCanvas(800, 800);
+
+  angleMode(DEGREES);
+
+  fill(255);
+  textSize(20);
+  textAlign(CENTER, CENTER);
+
+  // Set the color mode to hue-saturation-brightness (HSB)
+  colorMode(HSB);
+  background(0);
+  // Create screen reader accessible description
+  describe('Left 4 Dead 2 Map Roulette');
+}
+function draw_roulette() {
+  let i = 1;
+  let current_map = ""
+  for (let angle = 0; angle <= 336; angle += 24) {
+    // Save current coordinate system
+    push();
+
+    // Translate to center of canvas and rotate by angle
+    translate(0, 0);
+    rotate(angle);
+
+    // Set color based on angle and draw arc representing each circle slice
+    colour_slice = angle;
+    stroke(angle, 100, 100);
+    fill(angle, 100, 50);
+    strokeWeight(5);
+    //line(0, 0, 250, 0);
+    arc(0, 0, 600, 600, 0, PI * 7.6);
+    if (i <= 14) {
+      current_map = Maps.get(i);
+      stroke(0);
+      fill(angle, 100, 100);
+      strokeWeight(2);
+      text(current_map, 220, 15);
+      maps_by_colour.set(colour_slice, current_map)
+      i += 1;
+      // Restore coordinate system
+      pop()
+    } else {
+      stroke(0);
+      fill(angle, 100, 100);
+      strokeWeight(2);
+      text("Cringe Map", 220, 15);
+      // Restore coordinate system
+      pop()
+    }
+  }
+}
+
+function draw() {
+  background(0);
+  static_lines();
+  translate(width / 2, height / 2);
+  rotate(frameCount / 20 * rotation_speed);
+  draw_roulette();
+  if (rotation_speed >= 0) {
+    rotation_speed -= 1
+  } else {
+    return get_map_name();
+  }
+}
+
+function static_lines() {
+  translate(0, 0)
+  stroke(0, 255, 255);
+  strokeWeight(5);
+  line(width, height, width - 180, height - 180);
+  line(width - 180, height - 180, width - 75, height - 150);
+  line(width - 180, height - 180, width - 150, height - 75);
+}
+
+function mousePressed() { // Spin the wheel. Random rotation does not work so far.
+  rotation_speed = floor(random(0, 360));
+}
+function get_map_name() { // Find hue from the RGB value returned by get
+  translate(0, 0);
+  final_colour = get(width - 200, height - 200)
+  let max_rg_b = Math.max(final_colour[0], final_colour[1], final_colour[2]);
+  let min_rg_b = Math.min(final_colour[0], final_colour[1], final_colour[2]);
+  let hue_final = 0;
+
+  // all greyscale colors have hue of 0deg
+  if (max_rg_b - min_rg_b == 0) {
+    hue_final = 0;
+  }
+
+  else if (max_rg_b == final_colour[0]) {
+    // if red is the predominant color
+    hue_final = (final_colour[1] - final_colour[2]) / (max_rg_b - min_rg_b);
+  }
+  else if (max_rg_b == final_colour[1]) {
+    // if green is the predominant color
+    hue_final = 2 + (final_colour[2] - final_colour[0]) / (max_rg_b - min_rg_b);
+  }
+  else if (max_rg_b == final_colour[2]) {
+    // if blue is the predominant color
+    hue_final = 4 + (final_colour[0] - final_colour[1]) / (max_rg_b - min_rg_b);
+  }
+
+  hue_final = hue_final * 60;
+
+  // make sure h is a positive angle on the color wheel between 0 and 360
+  hue_final %= 360;
+  if (hue_final < 0) {
+    hue_final += 360;
+  }
+  stroke(0);
+  fill(hue_final, 100, 100);
+  strokeWeight(15);
+  hue_final = Math.round(hue_final);
+  final_map = maps_by_colour.get(hue_final)
+  resetMatrix()
+  if (CringeMaps.includes(final_map) || final_map === undefined) {
+    text("CRINGE MAP: Time to reroll", width - 250, height - 30);
+  } else {
+    final_map = "The chosen map is: " + final_map
+    text(final_map, width - 250, height - 30);
+  }
+}


### PR DESCRIPTION
Currently the roulette is set to spin on its own and the RNG is faulty / doesn't work as intended and heavily prioritizes certain circle-slices that denote maps (guesstimate yellow -> green) . Changes are needed